### PR TITLE
Lots of improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,6 @@ commad with sufficient rights, from there:
     migrate-rg iid --gitlab-key xxxx \
       http://git.example.com/mygroup/myproject --check
 
-
 ### Import git repository
 
 A bare matter of `git remote set-url && git push`, see git documentation.
@@ -165,6 +164,26 @@ to reorganize your projects if you were using that feature of Redmine.
 If you want to.
 
 You're good to go :).
+
+### Optional: Redirect redmine to gitlab (for apache)
+
+Since redmine has a common *https://redmine.company.tld/issues/{issueid}* url for issues, you can't create a generic redirect in apache.
+
+This command creates redirect rules that you can place in your `.htaccess` file.
+
+    migrate-rg redirect --redmine-key xxxx --gitlab-key xxxx \
+      https://redmine.example.com/projects/myproject \
+      http://git.example.com/mygroup/myproject > htaccess.example
+
+The content of htaccess.example will be
+
+    # uncomment next line to enable RewriteEngine
+    # RewriteEngine On
+    # Redirects from https://redmine.example.com/projects/myproject to https://git.example.com/mygroup/myproject
+    RedirectMatch 301 ^/issues/1$ https://git.example.com/mygroup/myproject/issues/1
+    RedirectMatch 301 ^/issues/2$ https://git.example.com/mygroup/myproject/issues/2
+    ...
+    RedirectMatch 301 ^/issues/999$ https://git.example.com/mygroup/myproject/999
 
 Unit testing
 ------------

--- a/README.md
+++ b/README.md
@@ -15,14 +15,18 @@ Does
 - Per-project migrations
 - Migration of issues, keeping as much metadata as possible:
   - redmine trackers become tags
+  - redmine categories become tags
   - issues comments are kept and assigned to the right users
   - issues final status (open/closed) are kept along with open/close date (not
     detailed status history)
   - issues assignments are kept
   - issues numbers (ex: `#123`)
   - issues/notes authors
-  - issue/notes original dates, but as comments
-  - relations (although gitlab model for relations is simpler)
+  - issues/notes original dates, but as comments
+  - issue attachements
+  - issue related changesets
+  - issues custom fields (if specified) 
+  - relations including children and parent (although gitlab model for relations is simpler)
 - Migration of Versions/Roadmaps keeping:
   - issues composing the version
   - statuses & due dates
@@ -57,7 +61,8 @@ Requires
 - No preexisting issues on gitlab project
 - Already synced users (those required in the project you are migrating)
 
-(It was developed/tested arround redmine 2.5.2, gitlab 8.2.0, python 3.4)
+(Original version was developed/tested around redmine 2.5.2, gitlab 8.2.0, python 3.4)
+(Updated version was developed/tested around redmine 2.1.2, gitlab 8.12.1, python 3.4)
 
 
 Let's go
@@ -123,6 +128,19 @@ Note that your issue titles will be annotated with the original redmine issue
 ID, like *-RM-1186-MR-logging*. This annotation will be used (and removed) by
 the next step.
 
+At least redmine 2.1.2 has no closed_on field, so you have to specify the names of the states which define closed issues. 
+defaults to closed,rejected
+
+    --closed-states closed,rejected,wontfix
+
+If you want to migrate redmine custom fields (as description), you can specify
+
+    --custom-fields Customer,ZendeskIssueId
+ 
+If you're using SSL with self signed cerificates and get an *requests.exceptions.SSLError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:600)* error, you can disable certificate validation with
+
+    --no-verify
+
 ### Migrate Issues ID (iid)
 
 You can retain the issues ID from redmine, **this cannot be done via REST
@@ -131,8 +149,7 @@ API**, thus it requires **direct access to the gitlab machine**.
 So you have to log in the gitlab machine (eg. via SSH), and then issue the
 commad with sufficient rights, from there:
 
-    migrate-rg iid --redmine --redmine-key xxxx --gitlab-key xxxx \
-      https://redmine.example.com/projects/myproject \
+    migrate-rg iid --gitlab-key xxxx \
       http://git.example.com/mygroup/myproject --check
 
 

--- a/redmine_gitlab_migrator/__init__.py
+++ b/redmine_gitlab_migrator/__init__.py
@@ -2,12 +2,17 @@ import logging
 
 import requests
 
+# http://stackoverflow.com/a/28002687/98491 
+from requests.packages.urllib3.exceptions import InsecureRequestWarning
+requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+
 log = logging.getLogger(__name__)
 
 
 class APIClient:
-    def __init__(self, api_key):
+    def __init__(self, api_key, verify):
         self.api_key = api_key
+        self.verify = verify
 
     def get_auth_headers(self):
         """ Method to be overloaded by child classes
@@ -21,6 +26,7 @@ class APIClient:
         headers = kwargs.get('headers', {})
         headers.update(self.get_auth_headers())
         _kwargs['headers'] = headers
+        _kwargs['verify'] = self.verify
         return _kwargs
 
     def _req(self, func, *args, **kwargs):

--- a/redmine_gitlab_migrator/converters.py
+++ b/redmine_gitlab_migrator/converters.py
@@ -98,7 +98,7 @@ def changesets_to_string(changesets):
         committed_on = i['committed_on']
         comments = i['comments']
 
-        l.append('  * Revision {} von {} am {}:\n```\n{}\n```'.format(revision, user, committed_on, comments))
+        l.append('  * Revision {} von {} am {}:\n\n```\n{}\n```\n'.format(revision, user, committed_on, comments))
 
     return "\n".join(l)
 

--- a/redmine_gitlab_migrator/converters.py
+++ b/redmine_gitlab_migrator/converters.py
@@ -3,23 +3,33 @@
 
 import logging
 
-
 log = logging.getLogger(__name__)
 
 # Utils
 
 
-def redmine_uid_to_login(redmine_id, redmine_user_index):
-    return redmine_user_index[redmine_id]['login']
+def redmine_uid_to_gitlab_user(redmine_id, redmine_user_index, gitlab_user_index):
+    redmine_login = redmine_user_index[redmine_id]['login']
+    return gitlab_user_index[redmine_login]
 
+def convert_attachment(redmine_issue_attachment, redmine_api_key):
+    """ Convert a list of redmine attachments to gitlab uploads
 
-def redmine_uid_to_gitlab_uid(redmine_id,
-                              redmine_user_index, gitlab_user_index):
-    username = redmine_uid_to_login(redmine_id, redmine_user_index)
-    return gitlab_user_index[username]['id']
+    :param redmine_issue_attachment: a dict describing redmine-api-style attachment
+    :param redmine_api_key: the redmine api key used for getting the attachment without logging in
+    :return: a dict describing the attachment
+    """
+    uploads = {
+        'filename': redmine_issue_attachment['filename'],
+        'description': redmine_issue_attachment.get('description'),
+        'content_url': '{}?key={}'.format(redmine_issue_attachment['content_url'], redmine_api_key),
+        'content_type': redmine_issue_attachment.get('content_type', 'application/octet-stream')
+    }
 
+    return uploads
+    
 
-def convert_notes(redmine_issue_journals, redmine_user_index):
+def convert_notes(redmine_issue_journals, redmine_user_index, gitlab_user_index):
     """ Convert a list of redmine journal entries to gitlab notes
 
     Filters out the empty notes (ex: bare status change)
@@ -37,8 +47,8 @@ def convert_notes(redmine_issue_journals, redmine_user_index):
             body = "{}\n\n*(from redmine: written on {})*".format(
                 journal_notes, entry['created_on'][:10])
             try:
-                author = redmine_uid_to_login(
-                    entry['user']['id'], redmine_user_index)
+                author = redmine_uid_to_gitlab_user(
+                    entry['user']['id'], redmine_user_index, gitlab_user_index)['username']
             except KeyError:
                 # In some cases you have anonymous notes, which do not exist in
                 # gitlab.
@@ -49,7 +59,7 @@ def convert_notes(redmine_issue_journals, redmine_user_index):
             yield {'body': body}, {'sudo_user': author}
 
 
-def relations_to_string(relations, issue_id):
+def relations_to_string(relations, children, parent_id, issue_id):
     """ Convert redmine formal relations to some denormalized string
 
     That's the way gitlab does relations, by "mentioning".
@@ -64,38 +74,106 @@ def relations_to_string(relations, issue_id):
             other_issue_id = i['issue_to_id']
         else:
             other_issue_id = i['issue_id']
-        l.append('{} #{}'.format(i['relation_type'], other_issue_id))
+        l.append('  * {} #{}'.format(i['relation_type'], other_issue_id))
 
-    return ', '.join(l)
+    for i in children:
+        id = i['id']        
+        l.append('  * {} #{}'.format('child', id))
 
+    if parent_id > 0:
+       l.append('  * {} #{}'.format('parent', parent_id))
+
+    return "\n".join(l)
+
+def changesets_to_string(changesets):
+    """ Convert redmine formal changesets to some denormalized string
+
+    :param changesets: list of issues changesets
+    :return a string listing changesets.
+    """
+    l = []
+    for i in changesets:
+        revision = i['revision']
+        user = i['user']['name']
+        committed_on = i['committed_on']
+        comments = i['comments']
+
+        l.append('  * Revision {} von {} am {}:\n```\n{}\n```'.format(revision, user, committed_on, comments))
+
+    return "\n".join(l)
+
+def custom_fields_to_string(custom_fields, custom_fields_include):
+    """ Convert redmine custom fields to some denormalized string
+
+    :param custom_fields: list of issues custom_fields
+    :return a string listing custom_fileds.
+    """
+    l = []
+    for i in custom_fields:
+        name = i['name']
+        
+        if name in custom_fields_include and i.get('value'):
+            # Name: Value
+            l.append('  * {}: {}'.format(name, i['value']))
+
+    return "\n".join(l)
 
 # Convertor
 
-def convert_issue(redmine_issue, redmine_user_index, gitlab_user_index,
-                  gitlab_milestones_index):
+def convert_issue(redmine_api_key, redmine_issue, redmine_user_index, gitlab_user_index,
+                  gitlab_milestones_index, closed_states, custom_fields_include):
+   
+    issue_state = redmine_issue['status']['name']
+
     if redmine_issue.get('closed_on', None):
         # quick'n dirty extract date
         close_text = ', closed on {}'.format(redmine_issue['closed_on'][:10])
+        closed = True
+    elif issue_state.lower() in closed_states:
+        close_text = ', closed (state: {})'.format(issue_state)
         closed = True
     else:
         close_text = ''
         closed = False
 
     relations = redmine_issue.get('relations', [])
-    relations_text = relations_to_string(relations, redmine_issue['id'])
-    if len(relations_text) > 0:
-        relations_text = ', ' + relations_text
+    children = redmine_issue.get('children', [])
+    parent_id = 0
+    if redmine_issue.get('parent', None):
+        parent_id = redmine_issue['parent']['id']
 
+    relations_text = relations_to_string(relations, children, parent_id, redmine_issue['id'])
+    if len(relations_text) > 0:
+        relations_text = "\n* Relations:\n" + relations_text
+
+    changesets = redmine_issue.get('changesets', [])
+    changesets_text = changesets_to_string(changesets)
+    if len(changesets_text) > 0:
+        changesets_text = "\n* Changesets:\n" + changesets_text
+
+    custom_fields = redmine_issue.get('custom_fields', [])
+    custom_fields_text = custom_fields_to_string(custom_fields, custom_fields_include)
+    if len(custom_fields_text) > 0:
+        custom_fields_text = "\n* Custom Fields:\n" + custom_fields_text
+
+    labels = [redmine_issue['tracker']['name']]
+    if (redmine_issue.get('category')):
+        labels.append(redmine_issue['category']['name'])
+
+    attachments = redmine_issue.get('attachments', [])
+  
     data = {
         'title': '-RM-{}-MR-{}'.format(
             redmine_issue['id'], redmine_issue['subject']),
-        'description': '{}\n\n*(from redmine: created on {}{}{})*'.format(
+        'description': '{}\n\n*(from redmine: created on {}{})*\n{}{}{}'.format(
             redmine_issue['description'],
             redmine_issue['created_on'][:10],
             close_text,
-            relations_text
+            relations_text,
+            changesets_text,
+            custom_fields_text
         ),
-        'labels': [redmine_issue['tracker']['name']]
+        'labels': labels,
     }
 
     version = redmine_issue.get('fixed_version', None)
@@ -103,8 +181,8 @@ def convert_issue(redmine_issue, redmine_user_index, gitlab_user_index,
         data['milestone_id'] = gitlab_milestones_index[version['name']]['id']
 
     try:
-        author_login = redmine_uid_to_login(
-            redmine_issue['author']['id'], redmine_user_index)
+        author_login = redmine_uid_to_gitlab_user(
+            redmine_issue['author']['id'], redmine_user_index, gitlab_user_index)['username']
 
     except KeyError:
         log.warning(
@@ -115,14 +193,21 @@ def convert_issue(redmine_issue, redmine_user_index, gitlab_user_index,
     meta = {
         'sudo_user': author_login,
         'notes': list(convert_notes(redmine_issue['journals'],
-                                    redmine_user_index)),
-        'must_close': closed
+                                    redmine_user_index, gitlab_user_index)),
+        'must_close': closed,
+        'uploads': list(convert_attachment(a, redmine_api_key) for a in attachments)
     }
 
     assigned_to = redmine_issue.get('assigned_to', None)
     if assigned_to is not None:
-        data['assignee_id'] = redmine_uid_to_gitlab_uid(
-            assigned_to['id'], redmine_user_index, gitlab_user_index)
+        try:
+            data['assignee_id'] = redmine_uid_to_gitlab_user(
+                assigned_to['id'], redmine_user_index, gitlab_user_index)['id']
+        except KeyError:
+            log.warning(
+                'Redmine issue #{} assignee is anonymous. gitlab assinee is attributed '
+                'to current admin\n'.format(redmine_issue['id']))
+
     return data, meta
 
 

--- a/redmine_gitlab_migrator/gitlab.py
+++ b/redmine_gitlab_migrator/gitlab.py
@@ -1,19 +1,26 @@
 import re
+import logging
+import requests
 
 from . import APIClient, Project
+from urllib.request import urlopen
 
+log = logging.getLogger(__name__)
 
 class GitlabClient(APIClient):
     # see http://doc.gitlab.com/ce/api/#pagination
     MAX_PER_PAGE = 100
 
     def get(self, *args, **kwargs):
-        # Note that we do not handle pagination, but as we rely on list data
-        # only for milestones, we assume that we have < 100 milestones. Could
-        # be fixed though...
         kwargs['params'] = kwargs.get('params', {})
+        kwargs['params']['page'] = 1
         kwargs['params']['per_page'] = self.MAX_PER_PAGE
-        return super().get(*args, **kwargs)
+
+        result = super().get(*args, **kwargs)
+        while (len(result) > 0 and len(result) % self.MAX_PER_PAGE == 0):
+            kwargs['params']['page'] += 1
+            result.extend(super().get(*args, **kwargs))	
+        return result 
 
     def get_auth_headers(self):
         return {"PRIVATE-TOKEN": self.api_key}
@@ -48,24 +55,84 @@ class GitlabProject(Project):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.api_url = (
-            '{base_url}api/v3/projects/{namespace}%2F{project_name}'.format(
-                **self._url_match.groupdict()))
+
         self.instance_url = '{}/api/v3'.format(
             self._url_match.group('base_url'))
+
+        # fetch project_id via api, thanks to lewicki-pk 
+        # https://github.com/oasiswork/redmine-gitlab-migrator/pull/2
+        # but also take int account, that there might be the same project in different namespaces
+        path_with_namespace = (
+            '{namespace}/{project_name}'.format(
+                **self._url_match.groupdict())) 
+        projectId = -1
+
+        projects_info = self.api.get('{}/projects'.format(self.instance_url))
+ 
+        for project_attributes in projects_info:
+            if project_attributes.get('path_with_namespace') == path_with_namespace:
+                projectId = project_attributes.get('id')
+
+        self.project_id = projectId
+        if projectId == -1 :
+            raise ValueError('Could not get project_id for path_with_namespace: {}'.format(path_with_namespace))
+
+        self.api_url = (
+            '{base_url}api/v3/projects/'.format(
+                **self._url_match.groupdict())) + str(projectId)
+
 
     def is_repository_empty(self):
         """ Heuristic to check if repository is empty
         """
         return self.api.get(self.api_url)['default_branch'] is None
 
+    def uploads_to_string(self, uploads):
+
+        uploads_url = '{}/uploads'.format(self.api_url)
+        l = []
+        for u in uploads:
+
+           log.info('\tuploading {} ({} / {})'.format(u['filename'], u['content_url'], u['content_type']))
+
+           # http://docs.python-requests.org/en/latest/user/quickstart/#post-a-multipart-encoded-file 
+           # http://stackoverflow.com/questions/20830551/how-to-streaming-upload-with-python-requests-module-include-file-and-data
+           files = [("file", (u['filename'], urlopen(u['content_url']), u['content_type']))]
+
+           try:
+               upload = self.api.post(
+                   uploads_url, files=files)
+           except requests.exceptions.HTTPError:
+               # gitlab might throw an "ArgumentError (invalid byte sequence in UTF-8)" in production.log
+               # if the filename contains special chars like german "umlaute"
+               # in that case we retry with an ascii only filename. 
+               files = [("file", (self.remove_non_ascii(u['filename']), urlopen(u['content_url']), u['content_type']))]
+               upload = self.api.post(
+                   uploads_url, files=files)
+
+           l.append('{} {}'.format(upload['markdown'], u['description']))
+
+        return "\n  * ".join(l)
+
+    def remove_non_ascii(self, text):
+        # http://stackoverflow.com/a/20078869/98491
+        return ''.join([i if ord(i) < 128 else ' ' for i in text])
+
     def create_issue(self, data, meta):
         """ High-level issue creation
 
-        :param meta: dict with "sudo_user", "should_close" and "notes" keys
+        :param meta: dict with "sudo_user", "must_close", "notes" and "attachments" keys
         :param data: dict formatted as the gitlab API expects it
         :return: the created issue (without notes)
         """
+
+        # attachments have to be uploaded prior to creating an issue
+        # attachments are not related to an issue but can be referenced instead
+        # see: https://docs.gitlab.com/ce/api/projects.html#upload-a-file
+        uploads_text = self.uploads_to_string(meta['uploads'])
+        if len(uploads_text) > 0:
+           data['description'] = "{}\n* Uploads:\n  * {}".format(data['description'], uploads_text)
+
         issues_url = '{}/issues'.format(self.api_url)
         issue = self.api.post(
             issues_url, data=data, headers={'SUDO': meta['sudo_user']})
@@ -95,9 +162,14 @@ class GitlabProject(Project):
         :return: the created milestone
         """
         milestones_url = '{}/milestones'.format(self.api_url)
-        milestone = self.api.post(milestones_url, data=data)
 
-        if meta['must_close']:
+        # create milestone if not exists
+        try:
+            milestone = self.get_milestone_by_title(data['title'])
+        except ValueError:
+            milestone = self.api.post(milestones_url, data=data)
+
+        if (meta['must_close'] and milestone['state'] != 'closed'):
             milestone_url = '{}/{}'.format(milestones_url, milestone['id'])
             altered_milestone = milestone.copy()
             altered_milestone['state_event'] = 'close'
@@ -125,7 +197,14 @@ class GitlabProject(Project):
         for i in milestones:
             if i['id'] == _id:
                 return i
-        raise ValueError('Could not get milestone')
+        raise ValueError('Could not get milestone for id {}'.format(_id))
+
+    def get_milestone_by_title(self, _title):
+        milestones = self.get_milestones()
+        for i in milestones:
+            if i['title'] == _title:
+                return i
+        raise ValueError('Could not get milestone for title {}'.format(_title))
 
     def has_members(self, usernames):
         gitlab_user_names = set([i['username'] for i in self.get_members()])
@@ -138,3 +217,4 @@ class GitlabProject(Project):
         """ Return a GitlabInstance
         """
         return GitlabInstance(self.instance_url, self.api)
+

--- a/redmine_gitlab_migrator/sql.py
+++ b/redmine_gitlab_migrator/sql.py
@@ -13,6 +13,11 @@ FROM issues
 WHERE title ~* '{regex}' AND project_id={project_id};
 """
 
+UPDATE_IID_ISSUES = r"""
+UPDATE issues SET
+  iid = iid * 100000
+WHERE title ~* '{regex}' AND project_id={project_id};
+"""
 
 MIGRATE_IID_ISSUES = r"""
 UPDATE issues SET

--- a/redmine_gitlab_migrator/tests/fake.py
+++ b/redmine_gitlab_migrator/tests/fake.py
@@ -163,6 +163,103 @@ class FakeGitlabClient:
         if url.endswith('/users'):
             return [JOHN, JACK]
 
+        elif url.endswith('api/v3/projects'):
+            return [{
+                "id": 3,
+                "description": None,
+                "default_branch": "master",
+                "public": False,
+                "visibility_level": 0,
+                "ssh_url_to_repo":
+                "git@example.com:diaspora/diaspora-project-site.git",
+                "http_url_to_repo":
+                "http://example.com/diaspora/diaspora-project-site.git",
+                "web_url": "http://example.com/diaspora/diaspora-project-site",
+                "tag_list": [
+                    "example",
+                    "disapora project"
+                ],
+                "owner": {
+                    "id": 3,
+                    "name": "Diaspora",
+                    "created_at": "2013-09-30T13: 46: 02Z"
+                },
+                "name": "Diaspora Project Site",
+                "name_with_namespace": "Diaspora / Diaspora Project Site",
+                "path": "diaspora-project-site",
+                "path_with_namespace": "diaspora/diaspora-project-site",
+                "issues_enabled": True,
+                "merge_requests_enabled": True,
+                "wiki_enabled": True,
+                "snippets_enabled": False,
+                "created_at": "2013-09-30T13: 46: 02Z",
+                "last_activity_at": "2013-09-30T13: 46: 02Z",
+                "creator_id": 3,
+                "namespace": {
+                    "created_at": "2013-09-30T13: 46: 02Z",
+                    "description": "",
+                    "id": 3,
+                    "name": "Diaspora",
+                    "owner_id": 1,
+                    "path": "diaspora",
+                    "updated_at": "2013-09-30T13: 46: 02Z"
+                },
+                "permissions": {
+                    "project_access": {
+                        "access_level": 10,
+                        "notification_level": 3
+                    },
+                    "group_access": {
+                        "access_level": 50,
+                        "notification_level": 3
+                    }
+                },
+                "archived": False,
+                "avatar_url":
+                "http://example.com/uploads/project/avatar/3/uploads/avr.png"
+            },
+            {
+                "id": 6,
+                "description": None,
+                "default_branch": None,
+                "public": False,
+                "visibility_level": 0,
+                "ssh_url_to_repo": "git@example.com:brightbox/puppet.git",
+                "http_url_to_repo": "http://example.com/brightbox/puppet.git",
+                "web_url": "http://example.com/brightbox/puppet",
+                "tag_list": [
+                    "example",
+                    "puppet"
+                ],
+                "owner": {
+                    "id": 4,
+                    "name": "Brightbox",
+                    "created_at": "2013-09-30T13:46:02Z"
+                },
+                "name": "Puppet",
+                "name_with_namespace": "Brightbox / Puppet",
+                "path": "puppet",
+                "path_with_namespace": "brightbox/puppet",
+                "issues_enabled": True,
+                "merge_requests_enabled": True,
+                "wiki_enabled": True,
+                "snippets_enabled": False,
+                "created_at": "2013-09-30T13:46:02Z",
+                "last_activity_at": "2013-09-30T13:46:02Z",
+                "creator_id": 3,
+                "namespace": {
+                    "created_at": "2013-09-30T13:46:02Z",
+                    "description": "",
+                    "id": 4,
+                    "name": "Brightbox",
+                    "owner_id": 1,
+                    "path": "brightbox",
+                    "updated_at": "2013-09-30T13:46:02Z"
+                },
+                "archived": False,
+                "avatar_url": None
+            }]
+
         elif (url.endswith('/projects/3') or
               url.endswith('/projects/diaspora%2Fdiaspora-project-site')):
             return {
@@ -220,7 +317,8 @@ class FakeGitlabClient:
                 "http://example.com/uploads/project/avatar/3/uploads/avr.png"
             }
 
-        elif url.endswith('/projects/diaspora%2Fdiaspora-project-site/issues'):
+        elif (url.endswith('/projects/3/issues') or
+              url.endswith('/projects/diaspora%2Fdiaspora-project-site/issues')):
             return [
                 {
                     "id": 43,
@@ -283,8 +381,8 @@ class FakeGitlabClient:
                 }
             ]
 
-        elif url.endswith(
-                '/projects/diaspora%2Fdiaspora-project-site/members'):
+        elif (url.endswith('/projects/3/members') or
+              url.endswith('/projects/diaspora%2Fdiaspora-project-site/members')):
             return [JACK, JOHN]
 
         elif (url.endswith('/projects/6') or
@@ -330,10 +428,12 @@ class FakeGitlabClient:
                 "archived": False,
                 "avatar_url": None
             }
-        elif url.endswith('/projects/brightbox%2Fpuppet/issues'):
+        elif (url.endswith('/projects/6/issues') or
+              url.endswith('/projects/brightbox%2Fpuppet/issues')):
             return []
 
-        elif url.endswith('/projects/brightbox%2Fpuppet/members'):
+        elif (orl.endswith('/projects/6/members') or	
+              url.endswith('/projects/brightbox%2Fpuppet/members')):
             return []
 
         else:
@@ -430,6 +530,7 @@ class FakeRedmineClient:
             raise ValueError('{} is unknown data test'.format(url))
 
     def get(self, url):
+
         if url.endswith('projects/brightbox/puppet.json'):
             return {
                 "project": {

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ except IOError:
 
 setup(
     name='redmine-gitlab-migrator',
-    version='1.0.2',
+    version='1.0.3',
     description='Migrate a redmine project to gitlab',
     long_description=README,
     author='Jocelyn Delalande',


### PR DESCRIPTION
- works with current gitlab api (query projectId from namespace and project
  name for api url)
- works with self signed certificates
- imports related issue changesets
- imports related children and parent
- imports category as labels
- imports attachments
- pagination support for GitlabClient
- commandline switch --no-verify to disable SSL certificate checks
- commandline switch --closed-states for issue closing based on redmine state name as fallback
- commandline switch --custom-fields to import some custom fields
- updated unit tests
- updated docs
- updated version to 1.0.3
- several bugfixes
- command `redirect` which generates apache compatible rewrite rules for issues

tested with redmine 2.1.2 and gitlab 8.12
