### PR TITLE
Rename redmine admin user to gitlab root user.

### DIFF
--- a/redmine_gitlab_migrator/redmine.py
+++ b/redmine_gitlab_migrator/redmine.py
@@ -113,7 +113,7 @@ class RedmineProject(Project):
             if i != ANONYMOUS_USER_ID:
                 user = self.api.get('{}/users/{}.json'.format(
                     self.instance_url, i))
-                if user['login'] == 'admin':
+                if (user['login'] == 'admin') or not user['login']:
                     user['login'] = 'root'
                 users.append(user)
         return users

--- a/redmine_gitlab_migrator/redmine.py
+++ b/redmine_gitlab_migrator/redmine.py
@@ -113,7 +113,7 @@ class RedmineProject(Project):
             if i != ANONYMOUS_USER_ID:
                 user = self.api.get('{}/users/{}.json'.format(
                     self.instance_url, i))
-                if (user['login'] == 'admin') or not user['login']:
+                if user['login'] == 'admin':
                     user['login'] = 'root'
                 users.append(user)
         return users

--- a/redmine_gitlab_migrator/redmine.py
+++ b/redmine_gitlab_migrator/redmine.py
@@ -111,8 +111,11 @@ class RedmineProject(Project):
         for i in user_ids:
             # The anonymous user is not really part of the project...
             if i != ANONYMOUS_USER_ID:
-                users.append(self.api.get('{}/users/{}.json'.format(
-                    self.instance_url, i)))
+                user = self.api.get('{}/users/{}.json'.format(
+                    self.instance_url, i))
+                if user['login'] == 'admin':
+                    user['login'] = 'root'
+                users.append(user)
         return users
 
     def get_users_index(self):


### PR DESCRIPTION
In our redmine instances, some issues and comments were created by the admin user. This is not best practice, but it happened at some points in the past.

I was unable to rename the root user in gitlab, and I could not create a user with user name 'admin' either. So I hacked around the problem as you can see here.

I created this pull request because it might be useful for people running into the same problem as me. But I would not recommend merging it in master. It would be better to provide some generic user name mapping system via a command line option or something.
