### PR TITLE
Work around duplicate key issue when performing migrate-rg iid.

### DIFF
--- a/redmine_gitlab_migrator/commands.py
+++ b/redmine_gitlab_migrator/commands.py
@@ -179,6 +179,8 @@ def perform_migrate_iid(args):
         exit(1)
 
     if not args.check:
+        sql_cmd = sql.MESS_WITH_IID.format(project_id=gitlab_project_id)
+        sql.run_query(sql_cmd)
         sql_cmd = sql.MIGRATE_IID_ISSUES.format(
             regex=regex_saved_iid, project_id=gitlab_project_id)
         out = sql.run_query(sql_cmd)

--- a/redmine_gitlab_migrator/sql.py
+++ b/redmine_gitlab_migrator/sql.py
@@ -21,6 +21,9 @@ UPDATE issues SET
 WHERE title ~* '{regex}' AND project_id={project_id};
 """
 
+MESS_WITH_IID = r"""
+UPDATE issues SET iid = iid + 6000 WHERE project_id={project_id};
+"""
 
 def run_query(
         cmd,


### PR DESCRIPTION
I got this message when trying to update the iid's:

```
    ERROR:  duplicate key value violates unique constraint "index_issues_on_project_id_and_iid"
    DETAIL:  Key (project_id, iid)=(6, 1770) already exists.
```

I worked around it by adding a constant to all existing iids before updating
them based on the issue descriptions.

The constant (6000) is arbitrary, so this PR is not really ready to be merged.
I just share it for those running into the same problem.