### PR TITLE
remove Group IDs specific to one installation

### DIFF
--- a/redmine_gitlab_migrator/redmine.py
+++ b/redmine_gitlab_migrator/redmine.py
@@ -127,8 +127,9 @@ class RedmineProject(Project):
                 user_ids.add(entry['user']['id'])
 
         for i in user_ids:
-            # The anonymous user is not really part of the project... // ids are groups defined on our redmine instance
-            if i not in [ANONYMOUS_USER_ID, 35, 36, 37, 39, 52]:
+            # The anonymous user is not really part of the project...
+            # You may want to add Group IDs such as [ANONYMOUS_USER_ID, 324, 234, ...] if necessary
+            if i not in [ANONYMOUS_USER_ID]:
                 users.append(self.api.get('{}/users/{}.json'.format(
                     self.instance_url, i)))
         return users


### PR DESCRIPTION
I suppose these IDs have somehow been merged/commited by mistake.
Leaving these IDs hides legimate redmine users from other installations. I left the comment if anybody needs to hide "Group" Users from Redmine. Maybe adding a comment to the README would also help.