### PR TITLE
Making it more robust and work against the v4 api of Gitlab

### DIFF
--- a/redmine_gitlab_migrator/commands.py
+++ b/redmine_gitlab_migrator/commands.py
@@ -268,7 +268,7 @@ def perform_migrate_issues(args):
                     while redmine_id > last_iid + 1:
                         created = gitlab_project.create_issue({'title': 'fake'}, fake_meta)
                         last_iid = created['iid']
-                        gitlab_project.delete_issue(created['id'])
+                        gitlab_project.delete_issue(created['iid'])
                         log.info('#{iid} {title}'.format(**created))
                 except:
                     log.info('create issue "{}" failed'.format('fake'))

--- a/redmine_gitlab_migrator/converters.py
+++ b/redmine_gitlab_migrator/converters.py
@@ -279,7 +279,7 @@ def convert_version(redmine_version):
     milestone = {
         "title": redmine_version['name'],
         "description": '{}\n\n*(from redmine: created on {})*'.format(
-            redmine_version['description'],
+            redmine_version.get('description', ""),
             redmine_version['created_on'][:10])
     }
     if 'due_date' in redmine_version:

--- a/redmine_gitlab_migrator/converters.py
+++ b/redmine_gitlab_migrator/converters.py
@@ -220,10 +220,11 @@ def convert_issue(redmine_api_key, redmine_issue, redmine_user_index, gitlab_use
     else:
         creator_text = ''
 
+    description = redmine_issue.get('description', "")
     data = {
         'title': title,
         'description': '{}\n\n*(from redmine: issue id {}, created on {}{}{})*\n{}{}{}'.format(
-            textile_converter.convert(redmine_issue['description']),
+            textile_converter.convert(description),
             redmine_issue['id'],
             redmine_issue['created_on'][:10],
             creator_text,

--- a/redmine_gitlab_migrator/converters.py
+++ b/redmine_gitlab_migrator/converters.py
@@ -239,8 +239,7 @@ def convert_issue(redmine_api_key, redmine_issue, redmine_user_index, gitlab_use
 
     version = redmine_issue.get('fixed_version', None)
     if version:
-        if version['name'] in gitlab_milestones_index:
-            data['milestone_id'] = gitlab_milestones_index[version['name']]['id']
+        data['milestone_id'] = gitlab_milestones_index[version['name']]['id']
 
     meta = {
         'notes': list(convert_notes(redmine_issue['journals'],

--- a/redmine_gitlab_migrator/converters.py
+++ b/redmine_gitlab_migrator/converters.py
@@ -239,7 +239,8 @@ def convert_issue(redmine_api_key, redmine_issue, redmine_user_index, gitlab_use
 
     version = redmine_issue.get('fixed_version', None)
     if version:
-        data['milestone_id'] = gitlab_milestones_index[version['name']]['id']
+        if version['name'] in gitlab_milestones_index:
+            data['milestone_id'] = gitlab_milestones_index[version['name']]['id']
 
     meta = {
         'notes': list(convert_notes(redmine_issue['journals'],

--- a/redmine_gitlab_migrator/gitlab.py
+++ b/redmine_gitlab_migrator/gitlab.py
@@ -157,7 +157,7 @@ class GitlabProject(Project):
         issue = self.api.post(
             issues_url, data=data, headers=headers)
 
-        issue_url = '{}/{}'.format(issues_url, issue['id'])
+        issue_url = '{}/{}'.format(issues_url, issue['iid'])
 
         # Handle issues notes
         issue_notes_url = '{}/notes'.format(issue_url, 'notes')

--- a/redmine_gitlab_migrator/gitlab.py
+++ b/redmine_gitlab_migrator/gitlab.py
@@ -7,6 +7,8 @@ from urllib.request import urlopen
 
 from redmine_gitlab_migrator.converters import redmine_username_to_gitlab_username
 
+from json.decoder import JSONDecodeError
+
 log = logging.getLogger(__name__)
 
 class GitlabClient(APIClient):
@@ -177,7 +179,10 @@ class GitlabProject(Project):
 
     def delete_issue(self, iid):
         issue_url = '{}/issues/{}'.format(self.api_url, iid)
-        self.api.delete(issue_url)
+        try:
+            self.api.delete(issue_url)
+        except JSONDecodeError:
+            True
 
     def create_milestone(self, data, meta):
         """ High-level milestone creation

--- a/redmine_gitlab_migrator/gitlab.py
+++ b/redmine_gitlab_migrator/gitlab.py
@@ -68,7 +68,7 @@ class GitlabProject(Project):
         super().__init__(*args, **kwargs)
         self.group_id = None
 
-        self.instance_url = '{}/api/v3'.format(
+        self.instance_url = '{}/api/v4'.format(
             self._url_match.group('base_url'))
 
         # fetch project_id via api, thanks to lewicki-pk
@@ -95,7 +95,7 @@ class GitlabProject(Project):
             self.group_id = groupId
 
         self.api_url = (
-            '{base_url}api/v3/projects/'.format(
+            '{base_url}api/v4/projects/'.format(
                 **self._url_match.groupdict())) + str(projectId)
 
 

--- a/redmine_gitlab_migrator/gitlab.py
+++ b/redmine_gitlab_migrator/gitlab.py
@@ -62,7 +62,7 @@ class GitlabInstance:
 
 class GitlabProject(Project):
     REGEX_PROJECT_URL = re.compile(
-        r'^(?P<base_url>https?://[^/]+/)(?P<namespace>[\w\._/-]+)/(?P<project_name>[\w\._-]+)$')
+        r'^(?P<base_url>https?://[^/]+/)(?P<namespace>[\.\w\._/-]+)/(?P<project_name>[\w\._-]+)$')
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/redmine_gitlab_migrator/redmine.py
+++ b/redmine_gitlab_migrator/redmine.py
@@ -83,7 +83,7 @@ class RedmineProject(Project):
         if not hasattr(self, '_cache_issues'):
 
             issues = self.api.unpaginated_get(
-                '{}/issues.json?status_id=*'.format(self.public_url))
+                '{}/issues.json?subproject_id=1&status_id=*'.format(self.public_url))
             detailed_issues = []
             # It's impossible to get issue history from list view, so get it from
             # detail view...

--- a/redmine_gitlab_migrator/redmine.py
+++ b/redmine_gitlab_migrator/redmine.py
@@ -2,6 +2,7 @@ from itertools import chain
 import re
 
 from . import APIClient, Project
+from requests.exceptions import HTTPError
 
 ANONYMOUS_USER_ID = 2
 
@@ -130,8 +131,12 @@ class RedmineProject(Project):
             # The anonymous user is not really part of the project...
             # You may want to add Group IDs such as [ANONYMOUS_USER_ID, 324, 234, ...] if necessary
             if i not in [ANONYMOUS_USER_ID]:
-                users.append(self.api.get('{}/users/{}.json'.format(
-                    self.instance_url, i)))
+                try:
+                  users.append(self.api.get('{}/users/{}.json'.format(
+                      self.instance_url, i)))
+                except HTTPError:
+                  print("unable to retrieve user!")
+
         return users
 
     def get_users_index(self):

--- a/redmine_gitlab_migrator/tests/fake.py
+++ b/redmine_gitlab_migrator/tests/fake.py
@@ -163,7 +163,7 @@ class FakeGitlabClient:
         if url.endswith('/users'):
             return [JOHN, JACK]
 
-        elif url.endswith('api/v3/projects'):
+        elif url.endswith('api/v4/projects'):
             return [{
                 "id": 3,
                 "description": None,

--- a/redmine_gitlab_migrator/wiki.py
+++ b/redmine_gitlab_migrator/wiki.py
@@ -132,7 +132,7 @@ class WikiPageConverter():
         # save file with author/date
         file_name = title + ".md"
         with open(self.repo_path + "/" + file_name, mode='wt', encoding='utf-8') as fd:
-            print(text.replace('\n', "\n").encode('utf-8'), file=fd)
+            print(text.replace('\n', "\n"), file=fd)
 
         # todo: check for attachments
         # todo: upload attachments

--- a/redmine_gitlab_migrator/wiki.py
+++ b/redmine_gitlab_migrator/wiki.py
@@ -114,11 +114,11 @@ class WikiPageConverter():
                  else 'home')
         print("Converting {} ({} version {})".format(title, redmine_page["title"], redmine_page["version"]))
 
-        text = redmine_page["text"]
+        text = redmine_page.get('text', "")
 
         # create a copy of the original page (for comparison, will not be committed)
         file_name = title + ".textile"
-        with open(self.repo_path + "/" + file_name, mode='w') as fd:
+        with open(self.repo_path + "/" + file_name, mode='wt', encoding='utf-8') as fd:
             print(text, file=fd)
 
         # replace some contents
@@ -131,8 +131,8 @@ class WikiPageConverter():
 
         # save file with author/date
         file_name = title + ".md"
-        with open(self.repo_path + "/" + file_name, mode='w') as fd:
-            print(text, file=fd)
+        with open(self.repo_path + "/" + file_name, mode='wt', encoding='utf-8') as fd:
+            print(text.replace('\n', "\n").encode('utf-8'), file=fd)
 
         # todo: check for attachments
         # todo: upload attachments


### PR DESCRIPTION
During my migration to GitLab Community Edition 11.1.2 the v3 api is not available anymore.
Also the namespace for personal accounts can contain a dot in the username.

Redmine has groups/users but you can't retrieve the group id at the user endpoint. We allow them to fail the user retrieval and set it as unknown.

Minor api v4 changes.