### PR TITLE
Pass auth headers to create_issue when keep-ids is enabled

### DIFF
--- a/redmine_gitlab_migrator/commands.py
+++ b/redmine_gitlab_migrator/commands.py
@@ -271,7 +271,7 @@ def perform_migrate_issues(args):
                     if args.sudo:
                         fake_meta['sudo_user'] = meta['sudo_user']
                     while redmine_id > last_iid + 1:
-                        created = gitlab_project.create_issue({'title': 'fake'}, fake_meta)
+                        created = gitlab_project.create_issue({'title': 'fake'}, fake_meta, gitlab.get_auth_headers())
                         last_iid = created['iid']
                         gitlab_project.delete_issue(created['iid'])
                         log.info('#{iid} {title}'.format(**created))


### PR DESCRIPTION
Issue migration with --keep-ids currently fails due to missing argument to create_issue(). This PR fixes it.