### PR TITLE
Migrate with Docker container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,4 +9,8 @@ build/
 *.egg-info
 dist/
 .idea/
+
+.git/
+docker-compose.yml
+Dockerfile
 srv/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM gitlab/gitlab-ce:latest
+
+ENV PANDOC_BIN=https://github.com/jgm/pandoc/releases/download/2.10.1/pandoc-2.10.1-1-amd64.deb
+
+RUN apt-get update && apt-get install -y \
+    sudo
+RUN wget -q ${PANDOC_BIN} && \
+    dpkg -i `basename ${PANDOC_BIN}` && \
+    rm -f `basename ${PANDOC_BIN}`
+
+COPY . /opt/redmine-gitlab-migrator
+RUN cd /opt/redmine-gitlab-migrator && \
+    python3 -m venv venv && \
+    . venv/bin/activate && \
+    python setup.py install && \
+    echo "#!/bin/sh\n. /opt/redmine-gitlab-migrator/venv/bin/activate\nmigrate-rg \$@" \
+    > /usr/local/bin/migrate-rg && \
+    chmod +x /usr/local/bin/migrate-rg

--- a/README.md
+++ b/README.md
@@ -247,3 +247,46 @@ Use the standard way:
     python setup.py test
 
 Or use whatever test runner you fancy.
+
+Using Docker container
+----------------------
+
+### Start up GitLab with migrator
+
+cf. [GitLab Docs](https://docs.gitlab.com/) > Omnibus GitLab Doc > [GitLab Docker images](https://docs.gitlab.com/omnibus/docker/)
+
+    export GITLAB_HOME=$PWD/srv/gitlab
+    docker-compose up -d
+    docker-compose logs -f  # You can watch logs and stop with Ctrl+C
+
+After starting a container you can access GitLab http://localhost:8081
+
+- Create group/project and users
+- Create Access Token
+
+### Migrate with docker-compose command
+
+#### Roadmap
+
+    docker-compose exec migrator \
+      migrate-rg roadmap --redmine-key xxxx --gitlab-key xxxx \
+      https://redmine.example.com/projects/myproject \
+      http://localhost:8081/mygroup/myproject
+
+#### Issues
+
+    docker-compose exec migrator \
+      migrate-rg issues --redmine-key xxxx --gitlab-key xxxx \
+      https://redmine.example.com/projects/myproject \
+      http://localhost:8081/mygroup/myproject
+
+#### Issues ID (iid)
+
+    docker-compose exec migrator \
+      migrate-rg iid --gitlab-key xxxx \
+      http://localhost:8081/mygroup/myproject
+
+### Export/Import to production system
+
+cf. GitLab Docs
+GitLab Docs > User Docs > Projects > Project settings > [Project import/export](https://docs.gitlab.com/ee/user/project/settings/import_export.html)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3'
+services:
+  migrator:
+    build: .
+    hostname: 'localhost'
+    environment:
+      GITLAB_OMNIBUS_CONFIG: |
+        external_url 'http://localhost:8081'
+    ports:
+      - '8081:8081'
+    volumes:
+      - '$GITLAB_HOME/config:/etc/gitlab'
+      - '$GITLAB_HOME/logs:/var/log/gitlab'
+      - '$GITLAB_HOME/data:/var/opt/gitlab'


### PR DESCRIPTION
- Create Docker image
    - based on GitLab official image 
    - with this project and pandoc
- Startup temporary GitLab container with this migrator
- Migrate from Redmine
    - also iid
- Export project from temporary container
- Import to production GitLab system