### PR TITLE
Fix usage of the word 'exists' in help and warning messages

### DIFF
--- a/redmine_gitlab_migrator/commands.py
+++ b/redmine_gitlab_migrator/commands.py
@@ -128,7 +128,7 @@ def parse_args():
         '--archive-account', dest='archive_acc',
         required=False,
         default=None,
-        help="if account doesn't exists in GitLab use this account as default")
+        help="if account doesn't exist in GitLab use this account as default")
 
     parser_pages.add_argument(
         '--gitlab-wiki',

--- a/redmine_gitlab_migrator/converters.py
+++ b/redmine_gitlab_migrator/converters.py
@@ -261,7 +261,7 @@ def convert_issue(redmine_api_key, redmine_issue, redmine_user_index, gitlab_use
         if version['name'] in gitlab_milestones_index:
             data['milestone_id'] = gitlab_milestones_index[version['name']]['id']
         else:
-            print("Milestone {} doesn't exists in GitLab Project but exists in Redmine!".format(version['name']))
+            print("Milestone {} doesn't exist in GitLab Project but exists in Redmine!".format(version['name']))
 
     estimated_hours = redmine_issue.get('estimated_hours', 0)
     spent_hours = redmine_issue.get('spent_hours', 0)


### PR DESCRIPTION
While running the migrator recently, I noticed this minor grammatical issue in the help text and one of the warning messages and thought I'd submit a quick fix.  i hope this is helpful!  If you want anything changed/updated/extended, please let me know and I'll be happy to resubmit as required.