### PR TITLE
Fix typos in help text of commands

### DIFF
--- a/redmine_gitlab_migrator/commands.py
+++ b/redmine_gitlab_migrator/commands.py
@@ -86,12 +86,12 @@ def parse_args():
     parser_issues.add_argument(
         '--closed-states',
         required=False,
-        help="comma seperated list of redmine states that close an issue, default closed,rejected")
+        help="comma separated list of redmine states that close an issue, default closed,rejected")
 
     parser_issues.add_argument(
         '--custom-fields',
         required=False,
-        help="comma seperated list of redmine custom filds to migrate")
+        help="comma separated list of redmine custom fields to migrate")
 
     parser_issues.add_argument(
         '--user-dict',


### PR DESCRIPTION
When running the `--help` command for some of the commands I noticed
that the word "separated" was spelled incorrectly, and there was a
missing 'e' in the word "fields".  This commit corrects these issues.

This PR is submitted in the hope that it is useful. If you'd like something changed, please simply let me know and I'll be more than happy to update and resubmit as necessary.