### PR TITLE
To keep id, specify 'iid' instead of creating/deleting 'fake' issues

### DIFF
--- a/redmine_gitlab_migrator/commands.py
+++ b/redmine_gitlab_migrator/commands.py
@@ -280,18 +280,7 @@ def perform_migrate_issues(args):
 
         else:
             if args.keep_id:
-                try:
-                    fake_meta = {'uploads': [], 'notes': [], 'must_close': False, 'human_time_estimate': None, 'human_total_time_spent': None}
-                    if args.sudo:
-                        fake_meta['sudo_user'] = meta['sudo_user']
-                    while redmine_id > last_iid + 1:
-                        created = gitlab_project.create_issue({'title': 'fake'}, fake_meta, gitlab.get_auth_headers())
-                        last_iid = created['iid']
-                        gitlab_project.delete_issue(created['iid'])
-                        log.info('#{iid} {title}'.format(**created))
-                except:
-                    log.info('create issue "{}" failed'.format('fake'))
-                    raise
+                data['iid'] = redmine_id
             try:
                 created = gitlab_project.create_issue(data, meta, gitlab.get_auth_headers())
                 last_iid = created['iid']


### PR DESCRIPTION
It's supported since 11.2 according to the merge request:
https://gitlab.com/gitlab-org/gitlab-foss/-/merge_requests/20626

- This requires administrator or project owner rights. https://docs.gitlab.com/ee/api/issues.html#new-issue
- I'm using this code in my migrations to GitLab.com.