### PR TITLE
New option `--issue-ids` to migrate specific issues

### DIFF
--- a/redmine_gitlab_migrator/commands.py
+++ b/redmine_gitlab_migrator/commands.py
@@ -115,6 +115,11 @@ def parse_args():
         help="create and delete empty issues for gaps, useful when no ssh is possible (e.g. gitlab.com)")
 
     parser_issues.add_argument(
+        '--issue-ids',
+        required=False,
+        help="Comma separated issue IDs, to migrate specific issues")
+
+    parser_issues.add_argument(
         '--keep-title',
         required=False, action='store_true', default=False,
         help="migrate issues with same title, useful when no ssh is possible (e.g. gitlab.com) and don't need to keep id (faster)")
@@ -237,7 +242,7 @@ def perform_migrate_issues(args):
         gitlab_users_index = gitlab_project.get_members_index()
     else:
         gitlab_users_index = gitlab_instance.get_users_index()
-    redmine_users_index = redmine_project.get_users_index()
+    redmine_users_index = redmine_project.get_users_index(args.issue_ids)
     milestones_index = gitlab_project.get_milestones_index()
     if args.no_textile:
         textile_converter = NopConverter()
@@ -247,7 +252,7 @@ def perform_migrate_issues(args):
     log.debug('GitLab milestones are: {}'.format(', '.join(milestones_index) + ' '))
     # get issues
     log.info('Getting redmine issues')
-    issues = redmine_project.get_all_issues()
+    issues = redmine_project.get_issues(args.issue_ids)
     if args.initial_id:
         issues = [issue for issue in issues if int(args.initial_id) <= issue['id']]
 
@@ -391,7 +396,7 @@ def perform_redirect(args):
     redmine_project = RedmineProject(args.redmine_project_url, redmine)
 
     # get issues
-    redmine_issues = redmine_project.get_all_issues()
+    redmine_issues = redmine_project.get_issues(args.issue_ids)
 
     print('# uncomment next line to enable RewriteEngine')
     print('# RewriteEngine On')

--- a/redmine_gitlab_migrator/redmine.py
+++ b/redmine_gitlab_migrator/redmine.py
@@ -78,12 +78,17 @@ class RedmineProject(Project):
         else:
             return url
 
-    def get_all_issues(self):
+    def get_issues(self, issue_ids=""):
 
         if not hasattr(self, '_cache_issues'):
 
+            if issue_ids:
+                issue_ids_arg = "&issue_id=" + issue_ids
+            else:
+                issue_ids_arg = ""
+
             issues = self.api.unpaginated_get(
-                '{}/issues.json?subproject_id=1&status_id=*'.format(self.public_url))
+                '{}/issues.json?subproject_id=1&status_id=*{}'.format(self.public_url, issue_ids_arg))
             detailed_issues = []
             # It's impossible to get issue history from list view, so get it from
             # detail view...
@@ -105,7 +110,7 @@ class RedmineProject(Project):
         return self.api.get(
             '{}/wiki/{}/{}.json'.format(self.public_url, title, version))
 
-    def get_participants(self):
+    def get_participants(self, issue_ids=""):
         """Get participating users (issues authors/owners)
 
         :return: list of all users participating on issues
@@ -114,7 +119,7 @@ class RedmineProject(Project):
         user_ids = set()
         users = []
 
-        for i in self.get_all_issues():
+        for i in self.get_issues(issue_ids):
             journals = i.get('journals', [])
             for i in chain(i.get('watchers', []),
                            [i['author'], i.get('assigned_to', None)]):
@@ -139,10 +144,10 @@ class RedmineProject(Project):
 
         return users
 
-    def get_users_index(self):
+    def get_users_index(self, issue_ids=""):
         """ Returns dict index of users (by user id)
         """
-        return {i['id']: i for i in self.get_participants()}
+        return {i['id']: i for i in self.get_participants(issue_ids)}
 
     def get_versions(self):
         response = self.api.get('{}/versions.json'.format(self.public_url))

--- a/redmine_gitlab_migrator/tests/test_redmine.py
+++ b/redmine_gitlab_migrator/tests/test_redmine.py
@@ -12,7 +12,7 @@ class RedmineTestCase(unittest.TestCase):
         project = RedmineProject(
             'http://localhost:9000/projects/diaspora-site',
             self.client)
-        issues = project.get_all_issues()
+        issues = project.get_issues()
         self.assertEqual(len(issues), 2)
         self.assertEqual(len(issues[0].get('journals', [])), 0)
         self.assertEqual(len(issues[1].get('journals', [])), 2)


### PR DESCRIPTION
During migration to GitLab.com, the process was interrupted by some server side errors like 500 (internal server error) quite often.
This option allowed me to continue the interrupted migration instead of restarting everything.

This might also be useful for a situation like #69 .
