### PR TITLE
Fix Project Id Problem while handling subgroups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ srv/
 *~
 .cache
 .coverage
+.eggs
 .env
 keys.yml
 users.yml

--- a/redmine_gitlab_migrator/gitlab.py
+++ b/redmine_gitlab_migrator/gitlab.py
@@ -79,26 +79,8 @@ class GitlabProject(Project):
         path_with_namespace = (
             '{namespace}/{project_name}'.format(
                 **self._url_match.groupdict()))
-        projectId = -1
-        groupId = None
 
-        projects_info = self.api.get('{}/projects?owned=true'.format(self.instance_url))
-
-        for project_attributes in projects_info:
-            if project_attributes.get('path_with_namespace') == path_with_namespace:
-                projectId = project_attributes.get('id')
-                if project_attributes.get('namespace').get('kind') == 'group':
-                    groupId = project_attributes.get('namespace').get('id')
-
-        self.project_id = projectId
-        if projectId == -1 :
-            raise ValueError('Could not get project_id for path_with_namespace: {}'.format(path_with_namespace))
-        if groupId:
-            self.group_id = groupId
-
-        self.api_url = (
-            '{base_url}api/v4/projects/'.format(
-                **self._url_match.groupdict())) + str(projectId)
+        self.api_url = ('{base_url}api/v4/projects/{project_path}'.format(project_path=urllib.parse.quote(path_with_namespace, safe='', ), **self._url_match.groupdict()))
 
 
     def is_repository_empty(self):
@@ -281,4 +263,3 @@ class GitlabProject(Project):
         """ Return a GitlabInstance
         """
         return GitlabInstance(self.instance_url, self.api)
-

--- a/redmine_gitlab_migrator/tests/fake.py
+++ b/redmine_gitlab_migrator/tests/fake.py
@@ -382,7 +382,7 @@ class FakeGitlabClient:
             ]
 
         elif (url.endswith('/projects/3/members') or
-              url.endswith('/projects/diaspora%2Fdiaspora-project-site/members')):
+              url.endswith('/projects/diaspora%2Fdiaspora-project-site/members/all')):
             return [JACK, JOHN]
 
         elif (url.endswith('/projects/6') or
@@ -432,7 +432,7 @@ class FakeGitlabClient:
               url.endswith('/projects/brightbox%2Fpuppet/issues')):
             return []
 
-        elif (url.endswith('/projects/6/members') or	
+        elif (url.endswith('/projects/6/members') or
               url.endswith('/projects/brightbox%2Fpuppet/members')):
             return []
 


### PR DESCRIPTION
Changes to gitlab.py proposed in https://github.com/redmine-gitlab-migrator/redmine-gitlab-migrator/pull/35#issuecomment-1387381863 based on changes from https://github.com/redmine-gitlab-migrator/redmine-gitlab-migrator/pull/35#issuecomment-1106830805 which is based on https://github.com/redmine-gitlab-migrator/redmine-gitlab-migrator/pull/35#issuecomment-482302007

Also fix `python3 setup.py test` tests and adds .eggs to .gitignore