### PR TITLE
Fixes for Issue #80

### DIFF
--- a/redmine_gitlab_migrator/commands.py
+++ b/redmine_gitlab_migrator/commands.py
@@ -250,6 +250,10 @@ def perform_migrate_issues(args):
         textile_converter = TextileConverter()
 
     log.debug('GitLab milestones are: {}'.format(', '.join(milestones_index) + ' '))
+    if args.sudo:
+        migrator_user = 'root'
+    else:
+        migrator_user = gitlab_instance.get_user()['username']
     # get issues
     log.info('Getting redmine issues')
     issues = redmine_project.get_issues(args.issue_ids)
@@ -260,7 +264,7 @@ def perform_migrate_issues(args):
     log.info('Converting issues')
     issues_data = (
         convert_issue(args.redmine_key,
-            i, redmine_users_index, gitlab_users_index, milestones_index, closed_states, custom_fields, textile_converter,
+            i, redmine_users_index, gitlab_users_index, milestones_index, closed_states, custom_fields, textile_converter, migrator_user,
             args.keep_id or args.keep_title, args.sudo, args.archive_acc)
         for i in issues)
 

--- a/redmine_gitlab_migrator/gitlab.py
+++ b/redmine_gitlab_migrator/gitlab.py
@@ -38,6 +38,9 @@ class GitlabInstance:
         self.url = url.strip('/')  # normalize URL
         self.api = client
 
+    def get_user(self):
+        return self.api.get('{}/user'.format(self.url))
+
     def get_all_users(self):
         return self.api.get('{}/users'.format(self.url))
 

--- a/redmine_gitlab_migrator/tests/test_converters.py
+++ b/redmine_gitlab_migrator/tests/test_converters.py
@@ -40,7 +40,7 @@ class ConvertorTestCase(unittest.TestCase):
         textile_converter = TextileConverter()
         gitlab_issue, meta, redmine_id = convert_issue(
             redmine_api_key, redmine_issue, self.redmine_user_index, self.gitlab_users_idx, {}, ['closed', 'rejected'], ['customer'],
-            textile_converter, False, True, None)
+            textile_converter, 'jack_smith', False, True, None)
         self.assertEqual(gitlab_issue, {
             'title': '-RM-1732-MR-Update doc for v1',
             'created_at': '2015-08-21T13:29:41Z',
@@ -72,7 +72,7 @@ class ConvertorTestCase(unittest.TestCase):
         textile_converter = TextileConverter()
         gitlab_issue, meta, redmine_id = convert_issue(
             redmine_api_key, redmine_issue, self.redmine_user_index, self.gitlab_users_idx,
-            milestone_index, ['closed', 'rejected'], ['customer'], textile_converter, False, True, None)
+            milestone_index, ['closed', 'rejected'], ['customer'], textile_converter, 'john_smith', False, True, None)
 
         self.assertEqual(gitlab_issue, {
             'title': '-RM-1439-MR-Support SSL',


### PR DESCRIPTION
Fixes for Issue #80.
Set a non-existent redmine user in gitlab as a migrator instead of a root assignee.