### PR TITLE
Skip error and continue to next issue

### DIFF
--- a/redmine_gitlab_migrator/commands.py
+++ b/redmine_gitlab_migrator/commands.py
@@ -292,8 +292,11 @@ def perform_migrate_issues(args):
                 data['iid'] = redmine_id
             try:
                 created = gitlab_project.create_issue(data, meta, gitlab.get_auth_headers())
-                last_iid = created['iid']
-                log.info('#{iid} {title}'.format(**created))
+                if created == None:
+                    log.info('none')
+                else:
+                    last_iid = created['iid']
+                    log.info('#{iid} {title}'.format(**created))
             except:
                 log.info('create issue "{}" failed'.format(data['title']))
                 raise

--- a/redmine_gitlab_migrator/gitlab.py
+++ b/redmine_gitlab_migrator/gitlab.py
@@ -157,7 +157,7 @@ class GitlabProject(Project):
                 issues_url, data=data, headers=headers)
         except requests.exceptions.HTTPError as e:
             log.error("Can't convert issue due to error: {}".format(e.response.content))
-            exit()
+            return issue
 
 
         issue_url = '{}/{}'.format(issues_url, issue['iid'])


### PR DESCRIPTION
Thanks for this tool, it helped us so much!

When I started migrating issues I got a client error at the 20th issue. I wanted to start debugging it but it didn't want to run again cause 19 issues already exist on GitLab. So I modified the code to continue migrating even after it reports an error. It's kind of a messy code change using NoneType so feel free to reject or make it better.

A suggestion for improvement: make a new arg like --skip-errors that would enable this behaviour.