### PR TITLE
Fix redirect without issue ids

### DIFF
--- a/redmine_gitlab_migrator/commands.py
+++ b/redmine_gitlab_migrator/commands.py
@@ -400,7 +400,10 @@ def perform_redirect(args):
     redmine_project = RedmineProject(args.redmine_project_url, redmine)
 
     # get issues
-    redmine_issues = redmine_project.get_issues(args.issue_ids)
+    if hasattr(args, 'issue_ids'):
+        redmine_issues = redmine_project.get_issues(args.issue_ids)
+    else:
+        redmine_issues = redmine_project.get_issues()
 
     print('# uncomment next line to enable RewriteEngine')
     print('# RewriteEngine On')


### PR DESCRIPTION
When I wanted to do the redirect command without specyfing issue ids I got an error because the args object didn't have an attribute 'issue_ids'.

I changed the code so it checks whether it has this attribute at first.