### PR TITLE
Fix issues #42 and #63; correctness cleanups

### DIFF
--- a/redmine_gitlab_migrator/__init__.py
+++ b/redmine_gitlab_migrator/__init__.py
@@ -5,8 +5,8 @@ import time
 import requests
 
 # http://stackoverflow.com/a/28002687/98491
-from requests.packages.urllib3.exceptions import InsecureRequestWarning
-requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+import urllib3
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 log = logging.getLogger(__name__)
 
@@ -55,6 +55,9 @@ class APIClient:
                     time.sleep(retry_wait)
                     log.info("Retry {}".format(tri+1))
                     continue
+            # Some endpoints (e.g. DELETE) legitimately return an empty body.
+            if resp.status_code == 204 or not resp.content:
+                return None
             try:
                 return resp.json()
             except ValueError:

--- a/redmine_gitlab_migrator/commands.py
+++ b/redmine_gitlab_migrator/commands.py
@@ -66,6 +66,11 @@ def parse_args():
             '--gitlab-key',
             required=True,
             help="Gitlab administrator API key")
+        i.add_argument(
+            '--gitlab-url',
+            required=False, default=None,
+            help="Base URL of the GitLab instance (e.g. https://host/gitlab) "
+                 "when GitLab is not served at the root of the host")
 
     for i in (parser_issues, parser_pages, parser_roadmap, parser_iid, parser_redirect, delete_issues):
         i.add_argument(
@@ -114,10 +119,11 @@ def parse_args():
         required=False, action='store_true', default=False,
         help="create and delete empty issues for gaps, useful when no ssh is possible (e.g. gitlab.com)")
 
-    parser_issues.add_argument(
-        '--issue-ids',
-        required=False,
-        help="Comma separated issue IDs, to migrate specific issues")
+    for i in (parser_issues, parser_redirect):
+        i.add_argument(
+            '--issue-ids',
+            required=False, default=None,
+            help="Comma separated issue IDs, to migrate specific issues")
 
     parser_issues.add_argument(
         '--keep-title',
@@ -210,8 +216,8 @@ def perform_migrate_pages(args):
             try:
                 full_page = redmine_project.get_page(page["title"], version)
                 pages.append(full_page)
-            except:
-                log.error("Error when retrieving " + page["title"] + ", version " + str(version))
+            except Exception:
+                log.exception("Error when retrieving " + page["title"] + ", version " + str(version))
 
     # sort everything by date and convert
     pages.sort(key=lambda page: page["updated_on"])
@@ -235,7 +241,7 @@ def perform_migrate_issues(args):
     gitlab = GitlabClient(args.gitlab_key, args.no_verify)
 
     redmine_project = RedmineProject(args.redmine_project_url, redmine)
-    gitlab_project = GitlabProject(args.gitlab_project_url, gitlab)
+    gitlab_project = GitlabProject(args.gitlab_project_url, gitlab, base_url=args.gitlab_url)
 
     gitlab_instance = gitlab_project.get_instance()
     if (args.project_members_only):
@@ -294,7 +300,7 @@ def perform_migrate_issues(args):
                 created = gitlab_project.create_issue(data, meta, gitlab.get_auth_headers())
                 last_iid = created['iid']
                 log.info('#{iid} {title}'.format(**created))
-            except:
+            except Exception:
                 log.info('create issue "{}" failed'.format(data['title']))
                 raise
 
@@ -306,7 +312,7 @@ def perform_migrate_iid(args):
     # gitlab-rails dbconsole
 
     gitlab = GitlabClient(args.gitlab_key, args.no_verify)
-    gitlab_project = GitlabProject(args.gitlab_project_url, gitlab)
+    gitlab_project = GitlabProject(args.gitlab_project_url, gitlab, base_url=args.gitlab_url)
     gitlab_project_id = gitlab_project.get_id()
 
     regex_saved_iid = r'-RM-([0-9]+)-MR-(.*)'
@@ -345,6 +351,12 @@ def perform_migrate_iid(args):
             regex=regex_saved_iid, project_id=gitlab_project_id)
         out2 = sql.run_query(sql_cmd2)
 
+        # Advance the internal iid allocator so new issues don't reuse low iids
+        # that would collide with the migrated ones (issue #63).
+        sql_cmd3 = sql.UPDATE_INTERNAL_ID_ISSUES.format(
+            project_id=gitlab_project_id)
+        sql.run_query(sql_cmd3)
+
         try:
             m = re.match(
                 r'\s*(\d+)\s*', output,
@@ -360,7 +372,7 @@ def perform_delete_issues(args):
     """ Delete all issues in the gitlab repo
     """
     gitlab = GitlabClient(args.gitlab_key, args.no_verify)
-    gitlab_project = GitlabProject(args.gitlab_project_url, gitlab)
+    gitlab_project = GitlabProject(args.gitlab_project_url, gitlab, base_url=args.gitlab_url)
 
     gitlab_issues = gitlab_project.get_issues()
     log.debug('Got {} issue(s) from gitlab.'.format(len(gitlab_issues)))
@@ -374,7 +386,7 @@ def perform_migrate_roadmap(args):
     gitlab = GitlabClient(args.gitlab_key, args.no_verify)
 
     redmine_project = RedmineProject(args.redmine_project_url, redmine)
-    gitlab_project = GitlabProject(args.gitlab_project_url, gitlab)
+    gitlab_project = GitlabProject(args.gitlab_project_url, gitlab, base_url=args.gitlab_url)
 
     checks = [
         #(check_no_milestone, 'Gitlab project has no pre-existing milestone'),
@@ -399,11 +411,8 @@ def perform_redirect(args):
     redmine = RedmineClient(args.redmine_key, args.no_verify)
     redmine_project = RedmineProject(args.redmine_project_url, redmine)
 
-    # get issues
-    if hasattr(args, 'issue_ids'):
-        redmine_issues = redmine_project.get_issues(args.issue_ids)
-    else:
-        redmine_issues = redmine_project.get_issues()
+    # get issues (optionally filtered by --issue-ids)
+    redmine_issues = redmine_project.get_issues(args.issue_ids or "")
 
     print('# uncomment next line to enable RewriteEngine')
     print('# RewriteEngine On')

--- a/redmine_gitlab_migrator/gitlab.py
+++ b/redmine_gitlab_migrator/gitlab.py
@@ -7,8 +7,6 @@ from urllib.request import urlopen
 
 from redmine_gitlab_migrator.converters import redmine_username_to_gitlab_username
 
-from simplejson.errors import JSONDecodeError
-
 log = logging.getLogger(__name__)
 
 class GitlabClient(APIClient):
@@ -21,9 +19,14 @@ class GitlabClient(APIClient):
         kwargs['params']['per_page'] = self.MAX_PER_PAGE
 
         result = super().get(*args, **kwargs)
-        while (len(result) > 0 and len(result) % self.MAX_PER_PAGE == 0):
+        page = result
+        # Stop when a page is not full (fewer than per_page items). Using the
+        # per-page length rather than the accumulated total avoids an infinite
+        # loop when the total is an exact multiple of per_page.
+        while len(page) == self.MAX_PER_PAGE:
             kwargs['params']['page'] += 1
-            result.extend(super().get(*args, **kwargs))
+            page = super().get(*args, **kwargs)
+            result.extend(page)
         return result
 
     def get_auth_headers(self):
@@ -69,21 +72,37 @@ class GitlabProject(Project):
     REGEX_PROJECT_URL = re.compile(
         r'^(?P<base_url>https?://[^/]+/)(?P<namespace>[\.\w\._/-]+)/(?P<project_name>[\w\._-]+)$')
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, url, client, base_url=None):
+        super().__init__(url, client)
         self.group_id = None
 
-        self.instance_url = '{}/api/v4'.format(
-            self._url_match.group('base_url'))
+        # `base_url` is the GitLab instance root (e.g. https://host/gitlab). The
+        # URL regex alone can't tell a sub-path install (host/gitlab/group/proj)
+        # from a nested namespace (host/group/subgroup/proj), so when GitLab is
+        # not served at the host root the caller must say where it lives. See
+        # https://github.com/redmine-gitlab-migrator/redmine-gitlab-migrator/issues/42
+        if base_url:
+            base = base_url.rstrip('/')
+            prefix = base + '/'
+            if not self.public_url.startswith(prefix):
+                raise ValueError(
+                    '{} is not under the given gitlab base url {}'.format(
+                        self.public_url, base))
+            path_with_namespace = self.public_url[len(prefix):]
+        else:
+            # base_url regex group keeps a trailing '/'; drop it so we don't
+            # build a '//api/v4'.
+            base = self._url_match.group('base_url').rstrip('/')
+            # fetch project_id via api, thanks to lewicki-pk
+            # https://github.com/oasiswork/redmine-gitlab-migrator/pull/2
+            # but also take into account that the same project may exist in
+            # different namespaces
+            path_with_namespace = '{namespace}/{project_name}'.format(
+                **self._url_match.groupdict())
 
-        # fetch project_id via api, thanks to lewicki-pk
-        # https://github.com/oasiswork/redmine-gitlab-migrator/pull/2
-        # but also take int account, that there might be the same project in different namespaces
-        path_with_namespace = (
-            '{namespace}/{project_name}'.format(
-                **self._url_match.groupdict()))
-
-        self.api_url = ('{base_url}api/v4/projects/{project_path}'.format(project_path=urllib.parse.quote(path_with_namespace, safe='', ), **self._url_match.groupdict()))
+        self.instance_url = '{}/api/v4'.format(base)
+        self.api_url = '{}/api/v4/projects/{}'.format(
+            base, urllib.parse.quote(path_with_namespace, safe=''))
 
 
     def is_repository_empty(self):
@@ -106,7 +125,7 @@ class GitlabProject(Project):
            try:
                files = [("file", (u['filename'], urlopen(u['content_url']), u['content_type']))]
            except urllib.error.HTTPError as e:
-               log.warn("{} can't upload due to error: {}!".format(u['content_url'], e))
+               log.warning("{} can't upload due to error: {}!".format(u['content_url'], e))
 
 
            try:
@@ -123,7 +142,7 @@ class GitlabProject(Project):
                    upload = self.api.post(uploads_url, files=files)
                    l.append('{} {}'.format(upload['markdown'], u['description']))
                except urllib.error.HTTPError as e:
-                   log.warn("{} can't upload due to error: {}!".format(u['content_url'], e))
+                   log.warning("{} can't upload due to error: {}!".format(u['content_url'], e))
 
 
         return "\n  * ".join(l)
@@ -147,7 +166,9 @@ class GitlabProject(Project):
         uploads_text = self.uploads_to_string(meta['uploads'])
         if len(uploads_text) > 0:
            data['description'] = "{}\n* Uploads:\n  * {}".format(data['description'], uploads_text)
-        headers = auth_header
+        # Copy so the SUDO header we set below doesn't leak back into the
+        # shared auth_header (and thus into subsequent issues/notes).
+        headers = dict(auth_header)
         if 'sudo_user' in meta:
             headers['SUDO'] = meta['sudo_user']
         issues_url = '{}/issues'.format(self.api_url)
@@ -156,8 +177,13 @@ class GitlabProject(Project):
             issue = self.api.post(
                 issues_url, data=data, headers=headers)
         except requests.exceptions.HTTPError as e:
-            log.error("Can't convert issue due to error: {}".format(e.response.content))
-            exit()
+            log.error("Can't create issue due to error: {}".format(e.response.content))
+            if e.response.status_code == 404 and 'SUDO' in headers:
+                log.error(
+                    "Hint: the impersonated user '{}' may not be a member of "
+                    "the target project — GitLab returns 404 when the SUDO user "
+                    "cannot see it.".format(headers['SUDO']))
+            raise
 
 
         issue_url = '{}/{}'.format(issues_url, issue['iid'])
@@ -165,7 +191,7 @@ class GitlabProject(Project):
         # Handle issues notes
         issue_notes_url = '{}/notes'.format(issue_url, 'notes')
         for note_data, note_meta in meta['notes']:
-            note_headers = auth_header
+            note_headers = dict(auth_header)
             if 'sudo_user' in note_meta:
                 note_headers['SUDO'] = note_meta['sudo_user']
             self.api.post(
@@ -188,10 +214,8 @@ class GitlabProject(Project):
 
     def delete_issue(self, iid):
         issue_url = '{}/issues/{}'.format(self.api_url, iid)
-        try:
-            self.api.delete(issue_url)
-        except JSONDecodeError:
-            True
+        # DELETE returns 204 with an empty body; APIClient handles that.
+        self.api.delete(issue_url)
 
     def create_milestone(self, data, meta):
         """ High-level milestone creation

--- a/redmine_gitlab_migrator/sql.py
+++ b/redmine_gitlab_migrator/sql.py
@@ -27,6 +27,23 @@ UPDATE issues SET
 WHERE title ~* '{regex}' AND project_id={project_id};
 """
 
+# After rewriting the iids we must also advance GitLab's per-project iid
+# allocator (the internal_ids table, usage=0 is "issues"). Otherwise the next
+# newly-created issue reuses a low iid that will eventually collide with the
+# migrated ones. See https://github.com/redmine-gitlab-migrator/redmine-gitlab-migrator/issues/63
+#
+# The allocator row is keyed by project_id on older GitLab and by the project's
+# ProjectNamespace (internal_ids.namespace_id = projects.project_namespace_id)
+# on newer GitLab; match either so the fix works across versions.
+UPDATE_INTERNAL_ID_ISSUES = r"""
+UPDATE internal_ids SET
+  last_value = (SELECT MAX(iid) FROM issues WHERE project_id={project_id})
+WHERE usage=0 AND (
+  project_id={project_id}
+  OR namespace_id = (SELECT project_namespace_id FROM projects WHERE id={project_id})
+);
+"""
+
 
 def run_query(
         cmd,

--- a/redmine_gitlab_migrator/tests/test_bug_regressions.py
+++ b/redmine_gitlab_migrator/tests/test_bug_regressions.py
@@ -1,0 +1,93 @@
+"""Tests that pin down behaviour reported in GitHub bug issues.
+
+- `xfail` tests REPRODUCE a bug that is still open: they assert the *correct*
+  behaviour and are expected to fail until the bug is fixed (at which point they
+  flip to xpass and the marker can be removed).
+- The plain (passing) tests are REGRESSION guards for issues that the current
+  code already handles, so a future change can't silently reintroduce them.
+"""
+import pytest
+
+from redmine_gitlab_migrator.gitlab import GitlabProject
+from redmine_gitlab_migrator.converters import convert_issue
+from redmine_gitlab_migrator.wiki import NopConverter
+
+
+def _make_issue(**overrides):
+    """A minimal redmine-API-style issue dict for convert_issue()."""
+    issue = {
+        "id": 1,
+        "subject": "Something",
+        "description": "",
+        "created_on": "2020-01-01T00:00:00Z",
+        "status": {"name": "New"},
+        "tracker": {"name": "Bug"},
+        "priority": {"name": "Normal"},
+        "author": {"id": 1, "name": "Admin"},
+        "journals": [],
+    }
+    issue.update(overrides)
+    return issue
+
+
+def _convert(issue, milestones=None):
+    redmine_users = {1: {"id": 1, "login": "root"}}
+    gitlab_users = {"root": {"id": 1, "username": "root"}}
+    return convert_issue(
+        "apikey", issue, redmine_users, gitlab_users, milestones or {},
+        [], [], NopConverter(), "root", keep_title=False, sudo=True,
+        archive_acc=None)
+
+
+# --------------------------------------------------------------------------
+# #42 — GitLab installed at a sub-path of the host (not at the URL root)
+# https://github.com/redmine-gitlab-migrator/redmine-gitlab-migrator/issues/42
+#
+# Fixed by letting the caller pass the GitLab instance base URL (`--gitlab-url`
+# / `base_url=`); the URL regex alone can't tell a sub-path install from a
+# nested namespace.
+# --------------------------------------------------------------------------
+def test_issue42_gitlab_served_under_url_subpath():
+    project = GitlabProject("https://host.example.com/git/mygroup/myproject",
+                            client=object(),
+                            base_url="https://host.example.com/git")
+    # The '/git' sub-path survives into the API and instance URLs, and the
+    # namespace/project path is everything after the base.
+    assert project.instance_url == "https://host.example.com/git/api/v4"
+    assert project.api_url == (
+        "https://host.example.com/git/api/v4/projects/mygroup%2Fmyproject")
+
+
+def test_gitlab_at_host_root_still_works():
+    """Regression guard: without base_url, a nested namespace resolves correctly
+    and the instance URL has no '//api/v4' double slash."""
+    project = GitlabProject("https://host.example.com/group/subgroup/project",
+                            client=object())
+    assert project.instance_url == "https://host.example.com/api/v4"
+    assert project.api_url == (
+        "https://host.example.com/api/v4/projects/group%2Fsubgroup%2Fproject")
+
+
+# --------------------------------------------------------------------------
+# #14 — Issue import must not fail when the milestone/roadmap wasn't migrated
+# https://github.com/redmine-gitlab-migrator/redmine-gitlab-migrator/issues/14
+# Regression guard: an issue whose fixed_version has no matching GitLab
+# milestone should convert cleanly, just without a milestone_id.
+# --------------------------------------------------------------------------
+def test_issue14_missing_milestone_does_not_crash():
+    issue = _make_issue(fixed_version={"id": 9, "name": "NeverMigrated"})
+    data, meta, rid = _convert(issue, milestones={})  # empty milestone index
+    assert "milestone_id" not in data
+
+
+# --------------------------------------------------------------------------
+# #3 — Issue assigned to a Redmine *group* (not a user)
+# https://github.com/redmine-gitlab-migrator/redmine-gitlab-migrator/issues/3
+# Regression guard: a group assignee (whose id isn't a known user) must not
+# crash; the group name is preserved as a label instead.
+# --------------------------------------------------------------------------
+def test_issue3_group_assignee_becomes_label():
+    issue = _make_issue(assigned_to={"id": 777, "name": "DevTeam"})
+    data, meta, rid = _convert(issue)
+    assert "assignee_id" not in data          # group is not a mappable user
+    assert "DevTeam" in data["labels"].split(",")

--- a/redmine_gitlab_migrator/wiki.py
+++ b/redmine_gitlab_migrator/wiki.py
@@ -7,14 +7,30 @@ import unicodedata
 
 log = logging.getLogger(__name__)
 
+MIN_PANDOC_VERSION = (1, 17)
+
+
+def _pandoc_version_tuple():
+    """ '3.10.1' -> (3, 10, 1); tolerant of non-numeric suffixes. """
+    parts = []
+    for chunk in pypandoc.get_pandoc_version().split('.'):
+        digits = ''.join(c for c in chunk if c.isdigit())
+        parts.append(int(digits) if digits else 0)
+    return tuple(parts)
+
+
+def check_pandoc_version():
+    """ Numeric version check (a string compare mishandles e.g. 1.2 vs 1.17). """
+    if _pandoc_version_tuple() < MIN_PANDOC_VERSION:
+        log.error('You need at least pandoc {}, download from '
+                  'http://pandoc.org/installing.html'.format(
+                      '.'.join(str(n) for n in MIN_PANDOC_VERSION)))
+        exit(1)
+
+
 class TextileConverter():
     def __init__(self):
-        # make sure we use at least version 17 of pandoc
-        # TODO: fix this test, it will not work properly for version 1.2 or 1.100
-        version = pypandoc.get_pandoc_version()
-        if (version < "1.17"):
-            log.error('You need at least pandoc 1.17.0, download from http://pandoc.org/installing.html')
-            exit(1)
+        check_pandoc_version()
 
         # precompile regular expressions
         self.regexWikiLinkWithText = re.compile(r'\\\[\\\[\s*([^\]]*?)\s*\|\s*([^\]]*?)\s*\\\]\\\]')
@@ -127,12 +143,7 @@ class WikiPageConverter():
         self.repo_path = local_repo_path
         self.repo = Repo(local_repo_path)
 
-        # make sure we use at least version 17 of pandoc
-        # TODO: fix this test, it will not work properly for version 1.2 or 1.100
-        version = pypandoc.get_pandoc_version()
-        if (version < "1.17"):
-            log.error('You need at least pandoc 1.17.0, download from http://pandoc.org/installing.html')
-            exit(1)
+        check_pandoc_version()
 
         self.textile_converter = textile_converter
 


### PR DESCRIPTION
Source-only changes (no test/CI/packaging infra).

**Bug fixes**
- **#42** GitLab under a URL sub-path via `--gitlab-url` / `GitlabProject(base_url=...)`.
- **#63** advance the `internal_ids` counter after the `iid` SQL rewrite (handles project_id and namespace_id keyings).

**Cleanups**: drop `simplejson` (empty/204 body handling), copy auth headers so `SUDO` can't leak, `raise` instead of `exit()`, SUDO-404 hint, pagination infinite-loop fix, numeric pandoc version check, `log.warning`, `urllib3`, `except Exception`, `redirect --issue-ids`.

Adds `tests/test_bug_regressions.py`. Part of splitting #87.

Closes #42
Closes #63