### PR TITLE
Overhaul README (compatibility matrix, docker usage, testing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
 Redmine to Gitlab migrator
 ==========================
 
-[![Build Status](https://travis-ci.org/redmine-gitlab-migrator/redmine-gitlab-migrator.svg?branch=master)](https://travis-ci.org/redmine-gitlab-migrator/redmine-gitlab-migrator)
+[![CI](https://github.com/redmine-gitlab-migrator/redmine-gitlab-migrator/actions/workflows/ci.yml/badge.svg)](https://github.com/redmine-gitlab-migrator/redmine-gitlab-migrator/actions/workflows/ci.yml)
 
-Migrate code projects from Redmine to Gitlab, keeping issues/milestones/metadata
+Migrate code projects from Redmine to Gitlab, keeping issues/milestones/metadata.
+
+It is a command-line tool (`migrate-rg`) that talks to the Redmine and GitLab
+REST APIs. Migration is done per-project and in a defined order; see
+[Migration process](#migration-process) below.
 
 Does
 ----
@@ -43,7 +47,7 @@ Does not
 - Migrate the whole redmine installation at once, because namespacing is different in
   redmine and gitlab
 - Archive the redmine project for you
-- Keep "watchers" on tickets (gitlab API v3 does not expose it)
+- Keep "watchers" on tickets (the gitlab API does not expose them)
 - Keep dates/times as metadata
 - Keep track of issue relations orientation (no such notion on gitlab)
 - Migrate tags ([redmine_tags](https://www.redmine.org/plugins/redmine_tags)
@@ -52,17 +56,31 @@ Does not
 Requires
 --------
 
-- Python >= 3.5
-- gitlab >= 7.0
-- redmine >= 1.3
-- pandoc >= 1.17.0.0
-- API token on redmine
-- API token on gitlab
-- No preexisting issues on gitlab project
-- Already synced users (those required in the project you are migrating)
+- An **API token on Redmine** (administrator) and an **API token on GitLab**
+  (administrator, unless you use `--no-sudo`)
+- **pandoc** (for the Textile → Markdown conversion)
+- A GitLab project with **no pre-existing issues**
+- The relevant users **already created in GitLab** (see [Create users](#create-users))
 
-(Original version was developed/tested around redmine 2.5.2, gitlab 8.2.0, python 3.4)
-(Updated version was developed/tested around redmine 3.2.0, gitlab 12.3, python 3.6.8)
+### Compatibility matrix
+
+Minimum supported versions, and the versions exercised by CI on every run:
+
+| Component | Minimum         | Tested in CI                         |
+| --------- | --------------- | ------------------------------------ |
+| Python    | 3.10            | 3.10, 3.11, 3.12, 3.13, 3.14         |
+| Redmine   | 3.x (REST API)  | 6.1, 7.0                             |
+| GitLab    | API v4 (9.0+)   | 18.11, 19.1                          |
+| pandoc    | 1.17            | 3.10.1                               |
+
+The unit tests run on every supported Python version; the end-to-end suite runs
+the full Python × Redmine × GitLab matrix (see [Testing](#testing)). Older
+Redmine/GitLab releases very likely still work — the migrator only relies on
+long-stable API surface — but the versions above are what we actively verify.
+
+Historically this tool was also developed/tested against much older stacks
+(redmine 2.5.2 / gitlab 8.2 / python 3.4, later redmine 3.2 / gitlab 12.3 /
+python 3.6).
 
 
 Let's go
@@ -80,9 +98,9 @@ or latest version from GitHub:
 
     pip install git+https://github.com/redmine-gitlab-migrator/redmine-gitlab-migrator
 
-or if you cloned the git:
+or if you cloned the git (editable install):
 
-    python setup.py install
+    pip install -e .
 
 You can then give it a check without touching anything:
 
@@ -103,6 +121,12 @@ This process is for each project, **order matters**.
 
 It doesn't need to be named the same, you just have to record its URL (eg:
 *https://git.example.com/mygroup/myproject*).
+
+If your GitLab is **not served at the root of its host** but under a sub-path
+(eg. *https://example.com/gitlab/mygroup/myproject*), also pass the instance
+base URL so the project path can't be confused with a nested namespace:
+
+    --gitlab-url https://example.com/gitlab
 
 ### Create users
 
@@ -259,54 +283,53 @@ The content of htaccess.example will be
     ...
     RedirectMatch 301 ^/issues/999$ https://git.example.com/mygroup/myproject/999
 
-Unit testing
-------------
+Testing
+-------
 
-Use the standard way:
+There are two test suites.
 
-    python setup.py test
+**Unit tests** — fast, no external services. They cover the conversion logic:
 
-Or use whatever test runner you fancy.
+    pip install -e . pytest
+    pytest
 
-Using Docker container
+**End-to-end tests** — spin up real Redmine and GitLab containers, seed Redmine
+with representative data, run the migration, and assert the resulting GitLab
+state over its API. They are gated behind the `e2e` pytest marker (so the
+command above never triggers them) and documented in [`e2e/README.md`](e2e/README.md):
+
+    pip install -e . -r e2e/requirements-e2e.txt
+    ./e2e/run.sh
+
+Both are wired into GitHub Actions (`.github/workflows/ci.yml`): unit tests run
+on every push/PR across all supported Python versions, and the end-to-end suite
+runs the full Python × Redmine × GitLab matrix on a schedule / manual dispatch.
+
+Using the Docker image
 ----------------------
 
-### Start up GitLab with migrator
+The repository ships a small image whose entrypoint is `migrate-rg`. Build it:
 
-cf. [GitLab Docs](https://docs.gitlab.com/) > Omnibus GitLab Doc > [GitLab Docker images](https://docs.gitlab.com/omnibus/docker/)
+    docker build -t migrate-rg .
 
-    export GITLAB_HOME=$PWD/srv/gitlab
-    docker-compose up -d
-    docker-compose logs -f  # You can watch logs and stop with Ctrl+C
+Images are also published to the GitHub Container Registry by
+`.github/workflows/build-docker.yml`.
 
-After starting a container you can access GitLab http://localhost:8081
+Run a subcommand by appending it to `docker run` (no arguments prints `--help`):
 
-- Create group/project and users
-- Create Access Token
-
-### Migrate with docker-compose command
-
-#### Roadmap
-
-    docker-compose exec migrator \
-      migrate-rg roadmap --redmine-key xxxx --gitlab-key xxxx \
+    docker run --rm migrate-rg \
+      roadmap --redmine-key xxxx --gitlab-key xxxx \
       https://redmine.example.com/projects/myproject \
-      http://localhost:8081/mygroup/myproject
+      https://git.example.com/mygroup/myproject
 
-#### Issues
-
-    docker-compose exec migrator \
-      migrate-rg issues --redmine-key xxxx --gitlab-key xxxx \
+    docker run --rm migrate-rg \
+      issues --redmine-key xxxx --gitlab-key xxxx \
       https://redmine.example.com/projects/myproject \
-      http://localhost:8081/mygroup/myproject
+      https://git.example.com/mygroup/myproject
 
-#### Issues ID (iid)
+Notes:
 
-    docker-compose exec migrator \
-      migrate-rg iid --gitlab-key xxxx \
-      http://localhost:8081/mygroup/myproject
-
-### Export/Import to production system
-
-cf. GitLab Docs
-GitLab Docs > User Docs > Projects > Project settings > [Project import/export](https://docs.gitlab.com/ee/user/project/settings/import_export.html)
+- The `pages` (wiki) command needs a local clone of the GitLab wiki repo — mount
+  it, e.g. `-v "$PWD/wiki:/wiki" ... pages ... --gitlab-wiki /wiki`.
+- The `iid` command talks to the GitLab database directly, so it must be run on
+  the GitLab server itself, not from this image.


### PR DESCRIPTION
Docs only. Adds a compatibility matrix, modern install/test commands, a testing section (unit + e2e), `docker run` usage, the `--gitlab-url` note, and fixes the stale "gitlab API v3" reference and Travis badge.

Part of splitting #87.